### PR TITLE
Minor fixes

### DIFF
--- a/proman-nand.c
+++ b/proman-nand.c
@@ -278,6 +278,10 @@ int pm_read_id(pm_ctx* q) {
                     q->geo_blocks=4096;
                     q->manufacturer_str="Toshiba";
                     break;
+		case 0xdc:
+                    q->geo_blocks=2048;
+                    q->manufacturer_str="Macronix";
+                    break;	
 		case 0xda:
                     q->geo_blocks=1024;
                     q->manufacturer_str="Macronix";

--- a/proman-nand.c
+++ b/proman-nand.c
@@ -617,7 +617,7 @@ int main(int argc, char** argv)
     }
 
     q->devh = libusb_open_device_with_vid_pid(NULL, VENDOR_ID, PRODUCT_ID);
-	if (!q->devh) {
+    if (!q->devh) {
         if (q->verbose) fprintf(stderr, "Could not find/open ProMan device\n");
         goto end;
     }
@@ -687,7 +687,8 @@ int main(int argc, char** argv)
 
 
 end:
-    libusb_release_interface(q->devh, 0); 
+    if(q->devh)
+        libusb_release_interface(q->devh, 0); 
  
     // libusb_reset_device(devh); 
     libusb_close(q->devh); 


### PR DESCRIPTION
Added support for Macronix 4GB memory and fixed the segmentation fault / pointer deference if  the call to libusb_open_device_with_vid_pid() fails.